### PR TITLE
Remember Last Station Played

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.xbmc.pandorajson"
        name="Pandora Json"
-       version="1.3.02"
+       version="1.3.03"
        provider-name="spbogie, newatv2user">
   <requires>
     <import addon="xbmc.python" version="1.0"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.xbmc.pandorajson"
        name="Pandora Json"
-       version="1.3.05"
-       provider-name="spbogie, newatv2user">
+       version="1.3.06"
+       provider-name="spbogie, newatv2user, robweber">
   <requires>
     <import addon="xbmc.python" version="1.0"/>
   </requires>

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.xbmc.pandorajson"
        name="Pandora Json"
-       version="1.3.07"
+       version="1.4.0"
        provider-name="spbogie, newatv2user, robweber">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.xbmc.pandorajson"
        name="Pandora Json"
-       version="1.3.06"
+       version="1.3.07"
        provider-name="spbogie, newatv2user, robweber">
   <requires>
-    <import addon="xbmc.python" version="1.0"/>
+    <import addon="xbmc.python" version="2.1.0"/>
   </requires>
   <extension point="xbmc.python.script"
              library="default.py">

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.xbmc.pandorajson"
        name="Pandora Json"
-       version="1.3.03"
+       version="1.3.04"
        provider-name="spbogie, newatv2user">
   <requires>
     <import addon="xbmc.python" version="1.0"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.xbmc.pandorajson"
        name="Pandora Json"
-       version="1.3.04"
+       version="1.3.05"
        provider-name="spbogie, newatv2user">
   <requires>
     <import addon="xbmc.python" version="1.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,3 +19,4 @@
 1.3.00 Alternate code.
 1.3.01 Fixed Proxy code
 1.3.02 Pandora One Support
+1.3.03 remember last played station on startup

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,3 +21,4 @@
 1.3.02 Pandora One Support
 1.3.03 remember last played station on startup
 1.3.04 stop actually stops instead of skip
+1.3.05 make sure to quite visualation on stop

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,4 +21,5 @@
 1.3.02 Pandora One Support
 1.3.03 remember last played station on startup
 1.3.04 stop actually stops instead of skip
-1.3.05 make sure to quite visualation on stop
+1.3.05 make sure to quit visualation on stop
+1.3.06 fix crash on using "skip" command 

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,3 +20,4 @@
 1.3.01 Fixed Proxy code
 1.3.02 Pandora One Support
 1.3.03 remember last played station on startup
+1.3.04 stop actually stops instead of skip

--- a/default.py
+++ b/default.py
@@ -97,6 +97,7 @@ class Panda:
 
 	def playStation(self, stationId):
 		self.curStation = stationId
+		self.settings.setSetting('last_station',stationId)
 		self.curSong = None
 		self.playlist = []
 		self.getMoreSongs()

--- a/default.py
+++ b/default.py
@@ -81,6 +81,11 @@ class Panda:
 		self.gui = PandaGUI("script-pandora.xml", scriptPath, self.skinName)
 		
 		self.gui.setPanda(self)
+		
+		if(self.settings.getSetting('start_vis') == 'true'):
+			xbmc.executebuiltin("Skin.SetBool(PandoraVis)")
+		else:
+			xbmc.executebuiltin("Skin.Reset(PandoraVis)")
 
 	def auth(self):
 		dlg = xbmcgui.DialogProgress()

--- a/pandagui.py
+++ b/pandagui.py
@@ -27,6 +27,7 @@ class PandaGUI(xbmcgui.WindowXMLDialog):
 	def onInit(self):
 		print "PANDORA: Window Initalized!!!"
 		self.list = self.getControl(200)
+		playstation = -1
 		dlg = xbmcgui.DialogProgress()
 		dlg.create("PANDORA", "Fetching Stations")
 		dlg.update(0)
@@ -34,6 +35,10 @@ class PandaGUI(xbmcgui.WindowXMLDialog):
 			tmp = xbmcgui.ListItem(s.name)
 			tmp.setProperty("stationId", s.id)
 			self.list.addItem(tmp)
+
+			if(s.id == self.panda.settings.getSetting('last_station')):
+                                playstation = self.list.size() - 1
+                                
 		dlg.close()
 		self.getControl(BTN_THUMBED_DN).setVisible(False)
 		self.getControl(BTN_THUMBED_UP).setVisible(False)
@@ -41,6 +46,10 @@ class PandaGUI(xbmcgui.WindowXMLDialog):
 		logo = self.getControl(100)
 		if self.panda.settings.getSetting("logoSize") == "false":
 			logo.setPosition(-100, -100)
+
+		if(playstation != -1):
+                        self.list.selectItem(playstation)
+                        self.panda.playStation(self.panda.settings.getSetting('last_station'))
 
 	def onAction(self, action):
 		buttonCode = action.getButtonCode()

--- a/pandaplayer.py
+++ b/pandaplayer.py
@@ -45,8 +45,5 @@ class PandaPlayer(xbmc.Player):
 		print "PANDORA: playing = %s" % self.panda.playing
 		if self.timer and self.timer.isAlive():
 			self.timer.cancel()
-		if self.panda.playing:
-			if self.panda.skip:
-				self.panda.skip = False
-			self.timer = Timer(0.5, self.panda.playNextSong)
-			self.timer.start()
+		self.panda.stop()
+		

--- a/pandaplayer.py
+++ b/pandaplayer.py
@@ -45,5 +45,8 @@ class PandaPlayer(xbmc.Player):
 		print "PANDORA: playing = %s" % self.panda.playing
 		if self.timer and self.timer.isAlive():
 			self.timer.cancel()
-		self.panda.stop()
+		if xbmc.getCondVisibility('Skin.HasSetting(PandoraVis)'):
+                        xbmc.executebuiltin('Skin.Reset(PandoraVis)')
+		self.panda.Quit()
+		
 		

--- a/pandaplayer.py
+++ b/pandaplayer.py
@@ -45,8 +45,15 @@ class PandaPlayer(xbmc.Player):
 		print "PANDORA: playing = %s" % self.panda.playing
 		if self.timer and self.timer.isAlive():
 			self.timer.cancel()
-		if xbmc.getCondVisibility('Skin.HasSetting(PandoraVis)'):
-                        xbmc.executebuiltin('Skin.Reset(PandoraVis)')
-		self.panda.Quit()
+
+                #catch for if this was actually a skip
+                if self.panda.playing and self.panda.skip:
+                        self.panda.skip = False
+                        self.timer = Timer(0.5,self.panda.playNextSong)
+                        self.timer.start()
+                else:
+                        if xbmc.getCondVisibility('Skin.HasSetting(PandoraVis)'):
+                                xbmc.executebuiltin('Skin.Reset(PandoraVis)')
+                        self.panda.Quit()
 		
 		

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -23,8 +23,11 @@
 		visible="eq(-3,true)"/>
 	<setting id="proxy_pass" type="text" label="Proxy Password"
 		option="hidden" visible="eq(-4,true)"/>
+	<setting type="sep"/>
+	<setting id="start_vis" type="bool" label="Visualization on Start" default="true" />
 	<setting id="firstrun" type="bool" label="" visible="false"
 		default="true"/>
 	<setting id="last_station" type="text" label="" visible="false"
 		default=""/>
+	
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -25,4 +25,6 @@
 		option="hidden" visible="eq(-4,true)"/>
 	<setting id="firstrun" type="bool" label="" visible="false"
 		default="true"/>
+	<setting id="last_station" type="text" label="" visible="false"
+		default=""/>
 </settings>

--- a/resources/skins/Default/720p/script-pandora.xml
+++ b/resources/skins/Default/720p/script-pandora.xml
@@ -27,7 +27,6 @@
 			<posy>0</posy>
 			<texturenofocus>-</texturenofocus>
 			<texturefocus>-</texturefocus>
-			<onfocus>Skin.Reset(PandoraVis)</onfocus>
 			<onfocus>SetFocus(2000)</onfocus>
 			<ondown>200</ondown>
 			<onup>200</onup>


### PR DESCRIPTION
I had a use case in my home where I wanted to map the Pandora Addon to a remote button and not have to find my favorite station to resume play each time. 

I added a setting to keep track of the last station played. If that same station still exists the next time the addon is run it will resume playing on that same station when everything is done loading. If this is annoying for some people it could easily be set to look for a true/false "Play last station on startup" value as well. Let me know if this is something you want me to add as part of this pull request. 

I tried not to make it too "hackish" and I think I put the correct pieces where they would logically go in the code. Hopefully this is something others would find useful. 
